### PR TITLE
✨ Add window mirror/flip functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ cd tiling-tacos
 **Most used shortcuts:**
 - `Ctrl + Alt + hjkl` - Navigate windows  
 - `Ctrl + Cmd + f` - Toggle fullscreen
+- `Ctrl + Cmd + m` - Mirror/flip windows (180°)
 - `Ctrl + Cmd + Return` - Open terminal
 
 ## 🎯 What's This About?
@@ -64,7 +65,8 @@ Ctrl + Cmd + h/j/k/l        Resize window
 Ctrl + Cmd + f              Toggle fullscreen (yabai-style)
 Ctrl + Cmd + t              Toggle float
 Ctrl + Cmd + b              Balance space
-Ctrl + Cmd + r              Rotate space
+Ctrl + Cmd + r              Rotate space (270°)
+Ctrl + Cmd + m              Mirror/flip space (180°)
 Ctrl + Alt + Space          Cycle layouts (BSP ↔ Stack)
 ```
 

--- a/configs/.skhdrc
+++ b/configs/.skhdrc
@@ -37,6 +37,9 @@ ctrl + cmd - b : yabai -m space --balance
 # Rotate space (ctrl+cmd+r)
 ctrl + cmd - r : yabai -m space --rotate 270
 
+# Mirror/flip space 180 degrees (ctrl+cmd+m)
+ctrl + cmd - m : yabai -m space --rotate 180
+
 # ===== LAYOUTS =====
 
 # Cycle layouts (ctrl+alt+space)


### PR DESCRIPTION
## ✨ Add Window Mirror/Flip Functionality

### What's New
- **New shortcut**: `Ctrl + Cmd + m` for 180° window rotation
- Perfect complement to existing 270° rotation (`Ctrl + Cmd + r`)
- Enables quick window layout flipping for improved workflow

### Changes Made
- Added mirror keybinding to `.skhdrc` configuration
- Updated README with clear degree indicators for both shortcuts
- Added mirror shortcut to "most used" section for visibility

### Testing
- ✅ Functionality tested and working
- ✅ Services restarted successfully
- ✅ No conflicts with existing shortcuts

### Documentation
- Updated keyboard shortcuts section
- Added degree indicators (180° vs 270°) for clarity

### Usage
Press `Ctrl + Cmd + m` to flip your entire window layout 180 degrees - perfect for quickly reorganizing your workspace
